### PR TITLE
PDE-10458: Upgrade dependencies for Python 3.11 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ setup(
     py_modules=["tap_contentful"],
     python_requires=">=3.9",
     install_requires=[
-        "singer-python>=6,<7",
-        "requests>=2.31,<3",
-        "pendulum>=3,<4",
+        "singer-python==6.1.1",
+        "requests==2.32.3",
+        "pendulum==3.0.0",
         "tap-kit @ git+https://github.com/Radico/tap-kit.git@main",
     ],
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,12 @@ setup(
     url="http://simondata.com",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_contentful"],
+    python_requires=">=3.9",
     install_requires=[
-        "singer-python==5.2.0",
-        "requests==2.18.4",
-        "pendulum==1.2.0",
-        "tap-kit @ git+https://github.com/dmzobel/tap-kit.git@main"
-    ],
-    dependency_links=[
-        "https://github.com/dmzobel/tap-kit/tarball/main#egg=tap-kit-0.1.1",
+        "singer-python>=6,<7",
+        "requests>=2.31,<3",
+        "pendulum>=3,<4",
+        "tap-kit @ git+https://github.com/Radico/tap-kit.git@main",
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
## Summary
- Bumps `requests`, `singer-python`, `pendulum` to Python 3.11-compatible versions
- Points `tap-kit` at `Radico/tap-kit@main` instead of `dmzobel/tap-kit`
- Removes stale `dependency_links`
- Adds `python_requires=">=3.9"`

## Context
After the Python 3.9→3.11 upgrade (PDE-10351), this tap crashes on import:
```
ImportError: cannot import name 'Mapping' from 'collections'
```
Root cause: `requests==2.18.4` → `urllib3==1.22` uses `collections.Mapping`, removed in Python 3.10.

Jira: [PDE-10458](https://simondata.atlassian.net/browse/PDE-10458)

## Test plan
- [ ] Re-run `pipes-extract-wework-singer-contentful` Jenkins job and confirm it passes
- [ ] Verify extracted data lands in S3 as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PDE-10458]: https://simondata.atlassian.net/browse/PDE-10458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ